### PR TITLE
Fixed flag bug and also made flags show at scale

### DIFF
--- a/src/assets/stylesheets/components/_map.scss
+++ b/src/assets/stylesheets/components/_map.scss
@@ -100,8 +100,8 @@
   }
 
   img{
-    width: 20% !important;
-    height: auto !important;
+    width: auto !important;
+    height: .75em !important;
   }
 
   h2 {

--- a/src/assets/stylesheets/components/_map.scss
+++ b/src/assets/stylesheets/components/_map.scss
@@ -99,6 +99,11 @@
     margin-left: -.7em;
   }
 
+  img{
+    width: 20% !important;
+    height: auto !important;
+  }
+
   h2 {
     font-size: 1.5em;
     line-height: 1.2;

--- a/src/lib/coronavirus.js
+++ b/src/lib/coronavirus.js
@@ -11,17 +11,16 @@ import { commafy, friendlyDate } from 'lib/util';
 export function trackerLocationToFeature(location = {}) {
 
   const { countryInfo = {} } = location;
-  const { lat, long: lng, iso2 } = countryInfo;
+  const { lat, long: lng, iso2, flag } = countryInfo;
 
   const countryCode = iso2;
 
   let countryBounds;
-  let flag;
 
-  if ( typeof countryCode === 'string' ) {
-    countryBounds = getBoundsOfCountryByIsoAlpha2Code(countryCode);
-    flag = getEmojiFlag(countryCode);
-  }
+  // if ( typeof countryCode === 'string' ) {
+  //   countryBounds = getBoundsOfCountryByIsoAlpha2Code(countryCode);
+  //   //flag = getEmojiFlag(countryCode);
+  // }
 
   return {
     "type": "Feature",
@@ -65,6 +64,12 @@ export function trackerFeatureToHtmlMarker({ properties = {} } = {}) {
     deaths,
     recovered
   } = properties
+  console.log(flag)
+  let header = country;
+
+  if ( flag ) {
+    header = `<img src="${flag}" name="flag"> ${header}`;
+  }
 
   let stats = [
     {
@@ -127,7 +132,7 @@ export function trackerFeatureToHtmlMarker({ properties = {} } = {}) {
   return `
     <span class="icon-marker">
       <span class="icon-marker-tooltip">
-        <h2>${flag} ${country}</h2>
+        <h2>${header}</h2>
         <ul>${statsString}</ul>
       </span>
       ${ casesString }

--- a/src/lib/coronavirus.js
+++ b/src/lib/coronavirus.js
@@ -60,7 +60,7 @@ export function trackerFeatureToHtmlMarker({ properties = {} } = {}) {
     deaths,
     recovered
   } = properties
-  console.log(flag)
+  
   let header = country;
 
   if ( flag ) {

--- a/src/lib/coronavirus.js
+++ b/src/lib/coronavirus.js
@@ -17,10 +17,6 @@ export function trackerLocationToFeature(location = {}) {
 
   let countryBounds;
 
-  // if ( typeof countryCode === 'string' ) {
-  //   countryBounds = getBoundsOfCountryByIsoAlpha2Code(countryCode);
-  //   //flag = getEmojiFlag(countryCode);
-  // }
 
   return {
     "type": "Feature",

--- a/src/lib/coronavirus.js
+++ b/src/lib/coronavirus.js
@@ -134,4 +134,3 @@ export function trackerFeatureToHtmlMarker({ properties = {} } = {}) {
     </span>
   `;
 }
-

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -29,14 +29,6 @@ const IndexPage = () => {
 
   const hasCountries = Array.isArray(countries) && countries.length > 0;
 
-  // active: 1584170
-  // critical: 54536
-  // recovered: 606462
-
-  // todayCases: 21149
-  // todayDeaths: 1236
-  // updated: 1587302636236)
-
   /**
    * mapEffect
    * @description Fires a callback once the page renders


### PR DESCRIPTION
MS Zandaam will now use flag provided by API. I had to change your suggestion a little because it pulled an emoji, not a URL to the image. Please feel free to suggest a different approach if you feel it's better.

I also scaled the flags because the original size of the PNGs are huge. I made them show width at a fraction and then set height to auto to ensure that any flags outside of the typical 2:3 ratio will show accurately.